### PR TITLE
Support record:field as arrow edge

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -207,8 +207,20 @@ func (g Graph) IndentedWrite(w *IndentWriter) {
 		}
 		for _, each := range g.sortedEdgesFromKeys() {
 			all := g.edgesFrom[each]
+			var n1, n2 string
 			for _, each := range all {
-				fmt.Fprintf(w, "n%d%sn%d", each.from.seq, denoteEdge, each.to.seq)
+				if each.from.field == "" {
+					n1 = fmt.Sprintf("n%d", each.from.seq)
+				} else {
+					n1 = fmt.Sprintf("n%d:%s", each.from.seq, each.from.field)
+				}
+				if each.to.field == "" {
+					n2 = fmt.Sprintf("n%d", each.to.seq)
+				} else {
+					n2 = fmt.Sprintf("n%d:%s", each.to.seq, each.to.field)
+				}
+
+				fmt.Fprintf(w, "%s%s%s", n1, denoteEdge, n2)
 				appendSortedMap(each.attributes, true, w)
 				fmt.Fprint(w, ";")
 				w.NewLine()

--- a/node.go
+++ b/node.go
@@ -6,6 +6,7 @@ type Node struct {
 	graph *Graph
 	id    string
 	seq   int
+	field string
 }
 
 // Attr sets label=value and return the Node
@@ -32,4 +33,9 @@ func (n Node) Edge(toNode Node, labels ...string) Edge {
 // EdgesTo returns all existing edges between this Node and the argument Node.
 func (n Node) EdgesTo(toNode Node) []Edge {
 	return n.graph.FindEdges(n, toNode)
+}
+
+func (n Node) Field(field string) Node {
+	n.field = field
+	return n
 }


### PR DESCRIPTION
Support https://graphviz.gitlab.io/doc/info/shapes.html#record

e.g.

```go
node1.Edge(node2.Field("field_id_1"), "LABEL").
      Attr("shape", "vee")
```

```
n1->n2:field_id_1[label="LABEL",shape="vee"];
```